### PR TITLE
[SRS] Do not use fixed variables, even if LB==UB

### DIFF
--- a/src/SRS/srs_problem.c
+++ b/src/SRS/srs_problem.c
@@ -110,9 +110,6 @@ int mallocAndCopyStringArray(size_t arraySize, char const *const * sourceArray, 
 int computeColBoundType(double lb, double ub) {
 	if (lb > -SRS_infinite) {
 		if (ub < SRS_infinite) {
-			if (lb == ub) {
-				return VARIABLE_FIXE;
-			}
 			return VARIABLE_BORNEE_DES_DEUX_COTES;
 		}
 		return VARIABLE_BORNEE_INFERIEUREMENT;


### PR DESCRIPTION
Fixed variables make some problems infeasible in some cases. It is better not to use them.

Instead, variables will be bounded on both sides with LB==UB.