### PR TITLE
Ubuntu 22.04

### DIFF
--- a/.github/workflows/ubuntu-windows.yml
+++ b/.github/workflows/ubuntu-windows.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-20.04]
+        os: [windows-latest, ubuntu-20.04, ubuntu-22.04]
     steps:
       - name: is release created
         shell: bash


### PR DESCRIPTION
ubuntu-20.04 is being deprecated on GH Actions and in general. We add ubuntu-22.04 on branch `antares_integration`