### PR TITLE
Fix CMakeLists on metrix branch for cmake 4.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 3.12)
+PROJECT(sirius_solver)
+
+add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,0 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.12)
-PROJECT(sirius_solver)
-
-add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 3.12)
+PROJECT(sirius_solver)
+
 if(MSVC)
 	add_compile_definitions("_CRT_SECURE_NO_WARNINGS")
 	SET(BUILD_SHARED_LIBS OFF)


### PR DESCRIPTION
With Cmake 3.x, not using the method `CMAKE_MINIMUM_REQUIRED` in the CMakeLists.txt led to warnings raised during the build.

Since Cmake 4.0.0, it is now required to use the method `CMAKE_MINIMUM_REQUIRED` and an error will be thrown if it is not, which was the case in the metrix branch. It was already the case on the main branch.